### PR TITLE
add latest ca-certificates

### DIFF
--- a/nodejs/provisioning/playbook.yml
+++ b/nodejs/provisioning/playbook.yml
@@ -8,6 +8,9 @@
   tasks:
     - name: Install EPEL repo.
       yum: name=epel-release state=present
+      
+    - name: Install Root Certificates
+      yum: name=ca-certificates state=latest
 
     - name: Import Remi GPG key.
       rpm_key:


### PR DESCRIPTION
Without the latest root certificates installation of the Remi GPG key fails (old cert is expired in the distro).